### PR TITLE
PL - Adds form component, storybook page, and 100% test and mutation coverage

### DIFF
--- a/frontend/src/fixtures/addCourseStaffFixtures.js
+++ b/frontend/src/fixtures/addCourseStaffFixtures.js
@@ -1,0 +1,27 @@
+const addCourseStaffFixtures = {
+    oneCourseStaff: {
+        "id": 1,
+        "courseId": 12,
+        "githubId": 318493
+    },
+    threeCourseStaff: [
+        { 
+            "id": 1,
+            "courseId": 12,
+            "githubId": 318494
+        },
+        {
+            "id": 2,
+            "courseId": 123,
+            "githubId": 5184943
+        },
+        {
+            "id": 3,
+            "courseId": 51,
+            "githubId": 31415926
+        }
+    ]
+};
+
+
+export { addCourseStaffFixtures };

--- a/frontend/src/main/components/Courses/AddCourseStaffForm.js
+++ b/frontend/src/main/components/Courses/AddCourseStaffForm.js
@@ -1,0 +1,97 @@
+import { Button, Form, Row, Col } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+
+function AddCourseStaffForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+
+    const navigate = useNavigate();
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+
+            <Row>
+                {initialContents && (
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="id">Id</Form.Label>
+                            <Form.Control
+                                data-testid="AddCourseStaffForm-id"
+                                id="id"
+                                type="text"
+                                {...register("id")}
+                                value={initialContents.id}
+                                disabled
+                            />
+                        </Form.Group>
+                    </Col>
+                )}
+            </Row>
+
+            <Row>
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="courseId">courseId</Form.Label>
+                        <Form.Control
+                            data-testid="AddCourseStaffForm-courseId"
+                            id="courseId"
+                            type="text"
+                            isInvalid={Boolean(errors.courseId)}
+                            {...register("courseId", { required: true })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.courseId && 'courseId is required.'}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="githubId">Github Id</Form.Label>
+                        <Form.Control
+                            data-testid="AddCourseStaffForm-githubId"
+                            id="githubId"
+                            type="text"
+                            isInvalid={Boolean(errors.githubId)}
+                            {...register("githubId", { required: true })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.githubId && 'githubId is required. '}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
+
+            <Row>
+                <Col>
+                    <Button
+                        type="submit"
+                        data-testid="AddCourseStaffForm-submit"
+                    >
+                        {buttonLabel}
+                    </Button>
+                    <Button
+                        variant="Secondary"
+                        onClick={() => navigate(-1)}
+                        data-testid="AddCourseStaffForm-cancel"
+                    >
+                        Cancel
+                    </Button>
+                </Col>
+            </Row>
+        </Form>
+
+    )
+}
+
+export default AddCourseStaffForm

--- a/frontend/src/stories/components/Courses/AddCourseStaffForm.stories.js
+++ b/frontend/src/stories/components/Courses/AddCourseStaffForm.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import AddCourseStaffForm from 'main/components/Courses/AddCourseStaffForm';
+import { addCourseStaffFixtures } from 'fixtures/addCourseStaffFixtures';
+
+export default {
+    title: 'components/Courses/AddCourseStaffForm',
+    component: AddCourseStaffForm
+};
+
+
+const Template = (args) => {
+    return (
+        <AddCourseStaffForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: addCourseStaffFixtures.oneCourseStaff,
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/tests/components/Courses/AddCourseStaffForm.test.js
+++ b/frontend/src/tests/components/Courses/AddCourseStaffForm.test.js
@@ -1,0 +1,103 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import AddCourseStaffForm from "main/components/Courses/AddCourseStaffForm";
+import { addCourseStaffFixtures } from "fixtures/addCourseStaffFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("AddCourseStaffForm tests", () => {
+
+    test("renders correctly", async () => {
+
+        render(
+            <Router  >
+                <AddCourseStaffForm />
+            </Router>
+        );
+        await screen.findByText(/courseId/);
+        await screen.findByText(/Create/);
+    });
+
+
+    test("renders correctly when passing in a course staff", async () => {
+
+        render(
+            <Router  >
+                <AddCourseStaffForm initialContents={addCourseStaffFixtures.oneCourseStaff} />
+            </Router>
+        );
+        await screen.findByTestId(/AddCourseStaffForm-id/);
+        expect(screen.getByTestId(/AddCourseStaffForm-id/)).toHaveValue("1");
+        expect(screen.getByTestId(/AddCourseStaffForm-courseId/)).toHaveValue("12");
+        expect(screen.getByTestId(/AddCourseStaffForm-githubId/)).toHaveValue("318493");
+    });
+
+
+    test("Correct Error messsages on missing input", async () => {
+
+        render(
+            <Router  >
+                <AddCourseStaffForm />
+            </Router>
+        );
+        await screen.findByTestId("AddCourseStaffForm-submit");
+        const submitButton = screen.getByTestId("AddCourseStaffForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/courseId is required/);
+        expect(screen.getByText(/courseId is required/)).toBeInTheDocument();
+        expect(screen.getByText(/githubId is required/)).toBeInTheDocument();
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <AddCourseStaffForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("AddCourseStaffForm-courseId");
+
+        const courseId = screen.getByTestId("AddCourseStaffForm-courseId");
+        const githubId = screen.getByTestId("AddCourseStaffForm-githubId");
+        const submitButton = screen.getByTestId("AddCourseStaffForm-submit");
+
+        fireEvent.change(courseId, { target: { value: "156" } });
+        fireEvent.change(githubId, { target: { value: '1234' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText(/courseId is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/githubId is required./)).not.toBeInTheDocument();
+
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+
+        render(
+            <Router  >
+                <AddCourseStaffForm />
+            </Router>
+        );
+        await screen.findByTestId("AddCourseStaffForm-cancel");
+        const cancelButton = screen.getByTestId("AddCourseStaffForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});


### PR DESCRIPTION
If applied it will add the corresponding `AddCourseStaffForm.js` code, along with 100% test coverage and storybook page. This will be used as a basis for building pages and loading in data from the `Staff` table, along with this it adds the corresponding expected fixtures for further flexibility and frontend testing for future work dealing with this table.

Storybook form Acceptance Criteria:
<img width="1432" alt="image" src="https://github.com/ucsb-cs156-w24/proj-organic-w24-6pm-1/assets/68778019/edc38956-b773-4f2c-8ebd-3c2bca4a3bdc">


<img width="1440" alt="image" src="https://github.com/ucsb-cs156-w24/proj-organic-w24-6pm-1/assets/68778019/73618a32-73bc-4ce7-ac6d-a5101f9605ff">

closes #28 

